### PR TITLE
Add Quantum Swap ability

### DIFF
--- a/games/tag-me-if-you-can/README.md
+++ b/games/tag-me-if-you-can/README.md
@@ -25,6 +25,7 @@ side, so play happens on a continuous looped field.
 - **Browser refresh** – Restart the game after a Game Over.
 - **R** – Rewind to where you were two seconds ago (8‑second cooldown).
 - **D** – Deploy a holographic decoy that lures the AI for three seconds.
+- **Q** – Instantly swap positions with the AI (10‑second cooldown).
 
 ## Collectables and Boosts
 
@@ -57,3 +58,9 @@ chase the decoy instead of you for about three seconds, letting you reposition
 or escape danger. The decoy disappears on its own or when a new level loads.
 
 Enjoy the chase!
+
+## Quantum Swap
+
+Press **Q** to instantly trade places with the AI. This obscure ability can
+flip a dangerous situation in your favor or drop the AI into a trap. It has a
+ten‑second cooldown shown below the game.

--- a/games/tag-me-if-you-can/game.html
+++ b/games/tag-me-if-you-can/game.html
@@ -210,6 +210,7 @@
         <span id="boost-token-display">Boost Tokens: 0 / 5</span>
         <span id="shield-display">Shield: None</span>
         <span id="rewind-display">Rewind: Ready</span>
+        <span id="swap-display">Swap: Ready</span>
         <span>Controls: Arrow Keys | Spacebar = Boost</span>
         <span>D = Decoy</span>
     </div>
@@ -225,6 +226,7 @@
         const boostTokenDisplay = document.getElementById('boost-token-display');
         const shieldDisplay = document.getElementById('shield-display');
         const rewindDisplay = document.getElementById('rewind-display');
+        const swapDisplay = document.getElementById('swap-display');
 
         // --- Game Constants ---
         const gameAreaWidth = gameArea.offsetWidth;
@@ -254,6 +256,7 @@
         const rewindDuration = 2000; // How far back the rewind jumps (ms)
         const rewindCooldownTime = 8000; // Cooldown between rewinds (ms)
         const decoyDuration = 3000; // How long a decoy lasts (ms)
+        const swapCooldownTime = 10000; // Cooldown between quantum swaps (ms)
 
         // --- Game State Variables ---
         let playerPos = { x: 50, y: 50 };
@@ -279,6 +282,7 @@
         let isPaused = false;
         let aiShootCooldown = 0;
         let rewindCooldown = 0;
+        let swapCooldown = 0;
         let pastPositions = [];
         let decoyActive = false;
         let decoyPos = { x: 0, y: 0 };
@@ -426,6 +430,13 @@
                 rewindDisplay.textContent = `Rewind: ${(rewindCooldown/1000).toFixed(1)}s`;
             }
         }
+        function updateSwapDisplay() {
+            if (swapCooldown <= 0) {
+                swapDisplay.textContent = 'Swap: Ready';
+            } else {
+                swapDisplay.textContent = `Swap: ${(swapCooldown/1000).toFixed(1)}s`;
+            }
+        }
         function rewindPlayer() {
             if (rewindCooldown > 0 || pastPositions.length === 0 || gameOver || isPaused) return;
             const pos = pastPositions[0];
@@ -434,6 +445,7 @@
             pastPositions = [];
             rewindCooldown = rewindCooldownTime;
             updateRewindDisplay();
+            updateSwapDisplay();
             render();
         }
         function activateBoost() { /* ... same as before ... */
@@ -515,6 +527,19 @@
                 decoyActive = false;
                 decoyElement = null;
             }
+        }
+
+        function quantumSwap() {
+            if (swapCooldown > 0 || gameOver || isPaused) return;
+            const tempX = playerPos.x;
+            const tempY = playerPos.y;
+            playerPos.x = aiPos.x;
+            playerPos.y = aiPos.y;
+            aiPos.x = tempX;
+            aiPos.y = tempY;
+            swapCooldown = swapCooldownTime;
+            updateSwapDisplay();
+            render();
         }
 
         function movePlayerBullets() {
@@ -707,7 +732,12 @@
                 rewindCooldown -= gameLoopIntervalMs;
                 if (rewindCooldown < 0) rewindCooldown = 0;
             }
+            if (swapCooldown > 0) {
+                swapCooldown -= gameLoopIntervalMs;
+                if (swapCooldown < 0) swapCooldown = 0;
+            }
             updateRewindDisplay();
+            updateSwapDisplay();
             handlePlayerInput();
             moveAI();
             moveProjectiles();
@@ -765,6 +795,7 @@
                 boostTimer = null;
             }
             updateBoostTokenDisplay();
+            updateSwapDisplay();
             aiShootCooldown = aiShootCooldownTime / 2;
             const layoutIndex = levelNum % levelLayouts.length;
             const layout = levelLayouts[layoutIndex];
@@ -829,6 +860,11 @@
             if (key === 'r') {
                 e.preventDefault();
                 rewindPlayer();
+                return;
+            }
+            if (key === 'q') {
+                e.preventDefault();
+                quantumSwap();
                 return;
             }
             if (keysPressed.hasOwnProperty(e.key)) keysPressed[e.key] = true;


### PR DESCRIPTION
## Summary
- enable an obscure Quantum Swap ability triggered by **Q**
- display swap cooldown/ready state in the HUD
- document the new controls and mechanic

## Testing
- `node -c /tmp/temp_script.js`

------
https://chatgpt.com/codex/tasks/task_e_6846a592061c83259e184ff9f0747a00