### PR TITLE
Fix AI projectile collision with walls

### DIFF
--- a/games/tag-me-if-you-can/game.html
+++ b/games/tag-me-if-you-can/game.html
@@ -465,7 +465,24 @@
                 proj.pos = wrapPosition(proj.pos, projectileSize);
                 proj.element.style.left = proj.pos.x + 'px';
                 proj.element.style.top = proj.pos.y + 'px';
+
                 const projRect = getBoundingBox(null, proj.pos, projectileSize);
+
+                // Remove projectile if it hits any obstacle
+                let hitWall = false;
+                for (const obs of obstacles) {
+                    const obsRect = getObstacleBoundingBox(obs.data);
+                    if (isColliding(projRect, obsRect)) {
+                        if (proj.element.parentNode === gameArea) {
+                            gameArea.removeChild(proj.element);
+                        }
+                        projectiles.splice(i, 1);
+                        hitWall = true;
+                        break;
+                    }
+                }
+                if (hitWall) continue;
+
                 const playerRect = getBoundingBox(player, playerPos, characterSize);
                 if (isColliding(projRect, playerRect)) {
                     if (hasShield) {


### PR DESCRIPTION
## Summary
- prevent AI bullets from travelling through obstacles in the tag game

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6846a865b9e883258710237b6c043f5d