### PR TITLE
Remove AI control from tag game

### DIFF
--- a/games/tag-me-if-you-can/README.md
+++ b/games/tag-me-if-you-can/README.md
@@ -24,8 +24,6 @@ side, so play happens on a continuous looped field.
   player. Hitting the AI freezes it for a few seconds.
 - **Browser refresh** – Restart the game after a Game Over.
 - **D** – Deploy a holographic decoy that lures the AI for three seconds.
-- **C** – Temporarily control the AI's movement for two seconds
-  (12‑second cooldown). (to be removed)
 - **E** – Release a Temporal Echo that retraces your last two seconds of
   movement. If the echo touches the AI, it freezes for a moment
   (9‑second cooldown).
@@ -56,13 +54,6 @@ or escape danger. The decoy disappears on its own or when a new level loads.
 
 Enjoy the chase!
 
-
-## Puppeteer Hack
-
-Press **C** to override the AI and control its movement with the arrow keys
-for about two seconds. Your own player stays put while you steer the opponent.
-Use this to guide the AI into obstacles or away from boost tokens. The effect
-has a twelve‑second cooldown displayed at the bottom of the game.
 
 ## Temporal Echo
 

--- a/games/tag-me-if-you-can/game.html
+++ b/games/tag-me-if-you-can/game.html
@@ -242,12 +242,10 @@
         <span id="level-display">Level: 1</span>
         <span id="boost-token-display">Boost Tokens: 0 / 5</span>
         <span id="shield-display">Shield: None</span>
-        <span id="control-display">Control: Ready</span>
         <span id="echo-display">Echo: Ready</span>
         <span id="snare-display">Snare: Ready</span>
         <span>Controls: Arrow Keys | Spacebar = Boost</span>
         <span>D = Decoy</span>
-        <span>C = Control AI</span>
         <span>E = Temporal Echo</span>
     </div>
 
@@ -261,7 +259,6 @@
         const levelDisplay = document.getElementById('level-display');
         const boostTokenDisplay = document.getElementById('boost-token-display');
         const shieldDisplay = document.getElementById('shield-display');
-        const controlDisplay = document.getElementById('control-display');
         const echoDisplay = document.getElementById('echo-display');
         const snareDisplay = document.getElementById('snare-display');
 
@@ -292,8 +289,6 @@
         const aiMaxSpeed = basePlayerSpeed * 1.5; // Absolute speed cap for AI
         const historyDuration = 2000; // How long to keep past positions (ms)
         const decoyDuration = 3000; // How long a decoy lasts (ms)
-        const mindControlDuration = 2000; // How long player can control AI (ms)
-        const mindControlCooldownTime = 12000; // Cooldown between uses (ms)
         const echoCooldownTime = 9000; // Cooldown for Temporal Echo (ms)
         const snareDuration = 5000; // How long the snare stays on the field (ms)
         const snareFreezeDuration = 3000; // Freeze time when AI triggers snare
@@ -332,9 +327,6 @@
         let gameOver = false;
         let isPaused = false;
         let aiShootCooldown = 0;
-        let mindControlCooldown = 0;
-        let mindControlTimer = 0;
-        let mindControlActive = false;
         let pastPositions = [];
         let decoyActive = false;
         let decoyPos = { x: 0, y: 0 };
@@ -589,14 +581,6 @@
         function updateShieldDisplay() {
             shieldDisplay.textContent = hasShield ? 'Shield: Ready' : 'Shield: None';
         }
-        function updateControlDisplay() {
-            if (mindControlCooldown <= 0) {
-                controlDisplay.textContent = 'Control: Ready';
-            } else {
-                controlDisplay.textContent = `Control: ${(mindControlCooldown/1000).toFixed(1)}s`;
-            }
-        }
-
         function updateEchoDisplay() {
             if (echoCooldown <= 0) {
                 echoDisplay.textContent = 'Echo: Ready';
@@ -612,36 +596,10 @@
                 snareDisplay.textContent = `Snare: ${(snareCooldown/1000).toFixed(1)}s`;
             }
         }
-        function startMindControl() {
-            if (mindControlCooldown > 0 || mindControlActive || gameOver || isPaused) return;
-            mindControlActive = true;
-            mindControlTimer = mindControlDuration;
-            mindControlCooldown = mindControlCooldownTime;
-            playerVelocity.x = 0;
-            playerVelocity.y = 0;
-            updateControlDisplay();
-        }
         function activateBoost() { /* ... same as before ... */
             if (boostTokensCollected >= boostRequirement && !isBoosting && !gameOver) { isBoosting = true; boostTokensCollected -= boostRequirement; updateBoostTokenDisplay(); playerSpeed = basePlayerSpeed * 2; player.classList.add('boosting'); if (boostTimer) clearTimeout(boostTimer); boostTimer = setTimeout(() => { isBoosting = false; playerSpeed = basePlayerSpeed; player.classList.remove('boosting'); boostTimer = null; }, boostDuration); }
         }
         function handlePlayerInput() { /* ... same as before ... */
-            if (mindControlActive) {
-                let dx = 0; let dy = 0;
-                if (keysPressed.ArrowLeft) dx -= currentAiSpeed;
-                if (keysPressed.ArrowRight) dx += currentAiSpeed;
-                if (keysPressed.ArrowUp) dy -= currentAiSpeed;
-                if (keysPressed.ArrowDown) dy += currentAiSpeed;
-                let nextX = aiPos.x + dx;
-                let nextY = aiPos.y + dy;
-                let tempXPos = wrapPosition({ x: nextX, y: aiPos.y }, characterSize).x;
-                if (checkObstacleCollision({ x: tempXPos, y: aiPos.y })) { nextX = aiPos.x; }
-                let tempYPos = wrapPosition({ x: nextX, y: nextY }, characterSize).y;
-                if (checkObstacleCollision({ x: nextX, y: tempYPos })) { nextY = aiPos.y; }
-                aiPos.x = nextX;
-                aiPos.y = nextY;
-                aiPos = wrapPosition(aiPos, characterSize);
-                return;
-            }
             let dx = 0; let dy = 0; if (keysPressed.ArrowLeft) dx -= playerSpeed; if (keysPressed.ArrowRight) dx += playerSpeed; if (keysPressed.ArrowUp) dy -= playerSpeed; if (keysPressed.ArrowDown) dy += playerSpeed; playerVelocity.x = dx; playerVelocity.y = dy; let nextX = playerPos.x + dx; let nextY = playerPos.y + dy; let tempXPos = wrapPosition({ x: nextX, y: playerPos.y }, characterSize).x; if (checkObstacleCollision({ x: tempXPos, y: playerPos.y })) { nextX = playerPos.x; } let tempYPos = wrapPosition({ x: nextX, y: nextY }, characterSize).y; if (checkObstacleCollision({ x: nextX, y: tempYPos })) { nextY = playerPos.y; } playerPos.x = nextX; playerPos.y = nextY; playerPos = wrapPosition(playerPos, characterSize);
         }
         function createProjectile() { /* ... same as before ... */
@@ -833,7 +791,6 @@
             if (boostTokensCollected >= boostRequirement && !isBoosting) activateBoost();
             if (burstCooldown <= 0) fireBurst();
             if (!decoyActive) spawnDecoy();
-            if (mindControlCooldown <= 0 && !mindControlActive) startMindControl();
             if (echoCooldown <= 0 && !echoActive) spawnTemporalEcho();
             if (snareCooldown <= 0 && !snareActive) spawnSnare();
         }
@@ -1026,10 +983,6 @@
             while (pastPositions.length && Date.now() - pastPositions[0].t > historyDuration) {
                 pastPositions.shift();
             }
-            if (mindControlCooldown > 0) {
-                mindControlCooldown -= gameLoopIntervalMs;
-                if (mindControlCooldown < 0) mindControlCooldown = 0;
-            }
             if (echoCooldown > 0) {
                 echoCooldown -= gameLoopIntervalMs;
                 if (echoCooldown < 0) echoCooldown = 0;
@@ -1037,10 +990,6 @@
             if (snareCooldown > 0) {
                 snareCooldown -= gameLoopIntervalMs;
                 if (snareCooldown < 0) snareCooldown = 0;
-            }
-            if (mindControlActive) {
-                mindControlTimer -= gameLoopIntervalMs;
-                if (mindControlTimer <= 0) mindControlActive = false;
             }
             updateEchoDisplay();
             if (aiTeleportCooldown > 0) {
@@ -1068,7 +1017,7 @@
 
             updateSnareDisplay();
             handlePlayerInput();
-            if (!mindControlActive) moveAI();
+            moveAI();
             autoTriggerAbilitiesFunc();
             updateEcho();
             updateSnare();
@@ -1124,8 +1073,6 @@
             aiDashCooldown = aiDashCooldownTime;
             aiDashTimer = 0;
             aiCloneCooldown = aiCloneCooldownTime;
-
-            mindControlActive = false;
         }
         function loadLevel(levelNum) { /* ... same as before ... */
             clearLevelElements();
@@ -1148,7 +1095,6 @@
                 boostTimer = null;
             }
             updateBoostTokenDisplay();
-            updateControlDisplay();
             echoCooldown = 0;
             updateEchoDisplay();
             snareCooldown = 0;
@@ -1212,11 +1158,6 @@
             if (key === 'd') {
                 e.preventDefault();
                 spawnDecoy();
-                return;
-            }
-            if (key === 'c') {
-                e.preventDefault();
-                startMindControl();
                 return;
             }
             if (key === 'e') {


### PR DESCRIPTION
## Summary
- clean up README to drop mention of controlling the AI
- strip mind-control feature from game implementation

## Testing
- `node --check /tmp/script.js`

------
https://chatgpt.com/codex/tasks/task_e_684890f1234c8325a26e34ebd53cd93f